### PR TITLE
Fixed a parameter format error 

### DIFF
--- a/OSinstall.sh
+++ b/OSinstall.sh
@@ -333,7 +333,7 @@ case ${INSTALL} in
 		# Configure the networking for this environment
 		echo "Configuring OpenStack VM Network: ${VMNET} ${NUM_NETWORKS} ${NETWORK_SIZE}"
 		nova-manage db sync
-		nova-manage network create vmnet --fixed_range_v4=${VMNET}/${NETWORK_SIZE} --bridge_interface=${INTERFACE}
+		nova-manage network create vmnet --fixed_range_v4=${VMNET} --network_size=${NETWORK_SIZE} --bridge_interface=${INTERFACE}
 		nova-manage floating create --ip_range=${FLOATING_RANGE}
 		service libvirt-bin restart 2>&1 >> ${LOGFILE}
 		;;


### PR DESCRIPTION
--fixed_range_v4=${VMNET}/${NETWORK_SIZE} caused a "AddrFormatError: failed to detect IP version: '10.0.0.0/8/64'" exception because the network size was appended to the actual IP.

Separating the parameters should solve the issue.

Tested on 2011.3 (2011.3-nova-milestone-tarball:tarmac-20110922115702-k9nkvxqzhj130av2)
