### PR TITLE
Fixed service restarting 

### DIFF
--- a/OSinstall.sh
+++ b/OSinstall.sh
@@ -359,9 +359,13 @@ fi
 
 echo "Restarting service to finalize changes..."
 
-for P in ${NOVA_PACKAGES}
+for P in `ls /etc/init.d/nova* /etc/init.d/glance*`
 do
- service ${P} restart 2>&1 >> ${LOGFILE}
+ SERVICE_NAME=`basename ${P}`
+ service ${SERVICE_NAME} restart 2>&1 >> ${LOGFILE}
+ if [ "$?" != "0" ]; then
+   service ${SERVICE_NAME} start 2>&1 >> ${LOGFILE}
+ fi 
 done
 
 


### PR DESCRIPTION
The previous code didn't restart correctly glance (package name is different from service name) and nova-compute (because at the end of the installation it isn't running)

Now service names are taken directly from /etc/init.d and if a service fails to restart, we try to actually start it.
