### PR TITLE
Removed an assignment that always overrides the MYSQL_PASS setup

### DIFF
--- a/OSinstall.sh
+++ b/OSinstall.sh
@@ -312,8 +312,7 @@ if [ ! -z ${MYSQL_INSTALL} ]
 then
 	echo "Configuring MySQL for OpenStack"
 
-	# MySQL
-	MYSQL_PASS=nova
+	# MySQL	
 	cat <<MYSQL_PRESEED | debconf-set-selections
 mysql-server-5.1 mysql-server/root_password password $MYSQL_PASS
 mysql-server-5.1 mysql-server/root_password_again password $MYSQL_PASS


### PR DESCRIPTION
MYSQL_PASS is taken from the environment or assigned to a default defined at the beginning of file. The assignment was blindly bypassing this mechanism setting the password to 'nova'.
